### PR TITLE
Add methods to support the ASNum V6 database

### DIFF
--- a/py_GeoIP.c
+++ b/py_GeoIP.c
@@ -215,6 +215,21 @@ static PyObject *GeoIP_name_by_addr_Py(PyObject * self, PyObject * args)
     return ret;
 }
 
+static PyObject *GeoIP_name_by_addr_v6_Py(PyObject * self, PyObject * args)
+{
+    char *name;
+    char *org;
+    PyObject *ret;
+    GeoIP_GeoIPObject *GeoIP = (GeoIP_GeoIPObject *)self;
+    if (!PyArg_ParseTuple(args, "s", &name)) {
+        return NULL;
+    }
+    org = GeoIP_name_by_addr_v6(GeoIP->gi, name);
+    ret = Py_BuildValue("s", org);
+    free(org);
+    return ret;
+}
+
 static PyObject *GeoIP_name_by_name_Py(PyObject * self, PyObject * args)
 {
     char *name;
@@ -225,6 +240,21 @@ static PyObject *GeoIP_name_by_name_Py(PyObject * self, PyObject * args)
         return NULL;
     }
     org = GeoIP_name_by_name(GeoIP->gi, name);
+    ret = Py_BuildValue("s", org);
+    free(org);
+    return ret;
+}
+
+static PyObject *GeoIP_name_by_name_v6_Py(PyObject * self, PyObject * args)
+{
+    char *name;
+    char *org;
+    PyObject *ret;
+    GeoIP_GeoIPObject *GeoIP = (GeoIP_GeoIPObject *)self;
+    if (!PyArg_ParseTuple(args, "s", &name)) {
+        return NULL;
+    }
+    org = GeoIP_name_by_name_v6(GeoIP->gi, name);
     ret = Py_BuildValue("s", org);
     free(org);
     return ret;
@@ -580,6 +610,10 @@ static PyMethodDef GeoIP_Object_methods[] = {
       "Lookup City Region By IP Address" },
     { "record_by_name_v6",       GeoIP_record_by_name_v6_Py,       METH_VARARGS,
       "Lookup City Region By Name" },
+    { "name_by_addr_v6",         GeoIP_name_by_addr_v6_Py,         METH_VARARGS,
+      "Lookup IPv6 ASN, Domain, ISP and Organisation By IP Address" },
+    { "name_by_name_v6",         GeoIP_name_by_name_v6_Py,         METH_VARARGS,
+      "Lookup IPv6 ASN, Domain, ISP and Organisation By Name" },
     { NULL,                      NULL,                             0,
       NULL }
 };


### PR DESCRIPTION
The ASNum database is supported but not it's IPv6 counterpart. These two methods seem to be the minimal interface needed to work with this database (at least, they are enough for my use case):

GeoIP.name_by_name_v6
GeoIP.name_by_addr_v6

I've did some testing and they appear to work correctly (both with hostnames that have public IPv6 addresses and also raw IPv6 and IPv4-mapped IPv6 addresses).
