### PR TITLE
Encoding fixes for python 3.4

### DIFF
--- a/py_GeoIP.c
+++ b/py_GeoIP.c
@@ -789,7 +789,7 @@ GeoIP_populate_module(PyObject *m)
         CHECK_NULL(tmp = PyUnicode_FromString(GeoIP_country_code[i]));
         PyTuple_SET_ITEM(ccode, i, tmp);
 
-        CHECK_NULL(tmp = PyUnicode_FromString(GeoIP_country_name[i]));
+        CHECK_NULL(tmp = PyUnicode_FromString(GeoIP_utf8_country_name[i]));
         CHECK(PyDict_SetItemString(cname, GeoIP_country_code[i], tmp));
         Py_DECREF(tmp);
 


### PR DESCRIPTION
In **python 3.x** `PyUnicode_FromString()` function accepts an **UTF-8** encoded strings only.
But `country_code`, `country_name`, `country_continent` are all **ISO-8859-1** encoded.
This commit fixes the issue.

Before fix:

``` python
Python 3.4.1 (default, Aug 21 2014, 16:21:32) 
[GCC 4.6.3] on linux
>>> import GeoIP
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe7 in position 4: invalid continuation byte
```

After fix:

``` python
Python 3.4.1 (default, Aug 21 2014, 16:20:07) 
[GCC 4.6.3] on linux
>>> import GeoIP
>>> GeoIP.country_names['CW']
'Curaçao' 
```
