### PR TITLE
Use angle brackets for libGeoIP imports

### DIFF
--- a/py_GeoIP.c
+++ b/py_GeoIP.c
@@ -20,8 +20,8 @@
 
 #include <Python.h>
 
-#include "GeoIP.h"
-#include "GeoIPCity.h"
+#include <GeoIP.h>
+#include <GeoIPCity.h>
 
 #ifdef __GNUC__
     #  define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))


### PR DESCRIPTION
This apparently fixes #16.
